### PR TITLE
Improve auto-installer setup script and security

### DIFF
--- a/auto-installer/lambda/main.py
+++ b/auto-installer/lambda/main.py
@@ -11,14 +11,11 @@ Commands to be executed are hard-coded in the COMMAND_SCRIPT variable below.
 """
 
 # Python Built-Ins:
-import asyncio
-from datetime import datetime
 import json
 import logging
 import os
 import re
 import time
-import uuid
 
 # External Dependencies:
 import boto3
@@ -31,9 +28,10 @@ smclient = boto3.client("sagemaker")
 
 ENV_DOMAIN_ID = os.environ.get("SAGEMAKER_DOMAIN_ID")
 COMMAND_SCRIPT = [
-    "git clone https://github.com/aws-samples/sagemaker-studio-auto-shutdown-extension.git",
+    "rm -rf ~/.auto-shutdown",
+    "git clone https://github.com/aws-samples/sagemaker-studio-auto-shutdown-extension.git --depth 1 ~/.auto-shutdown",
     "pwd && ls",
-    "cd sagemaker-studio-auto-shutdown-extension && ./install_tarball.sh",
+    "cd ~/.auto-shutdown && ./install_tarball.sh",
 ]
 # Regular expression for determining when the terminal has finished executing the last command and is ready
 # for next input:

--- a/auto-installer/template.sam.yaml
+++ b/auto-installer/template.sam.yaml
@@ -63,6 +63,12 @@ Resources:
 
   CloudTrailBucket:
     Type: 'AWS::S3::Bucket'
+    Properties:
+      PublicAccessBlockConfiguration:
+        BlockPublicAcls: true
+        BlockPublicPolicy: true
+        IgnorePublicAcls: true
+        RestrictPublicBuckets: true
 
   CloudTrailBucketPolicy:
     Type: 'AWS::S3::BucketPolicy'
@@ -82,7 +88,7 @@ Resources:
             Principal:
               Service: cloudtrail.amazonaws.com
             Action: 's3:PutObject'
-            Resource: !Sub '${CloudTrailBucket.Arn}/*'
+            Resource: !Sub '${CloudTrailBucket.Arn}/AWSLogs/${AWS::AccountId}/*'
             Condition:
               StringEquals:
                 's3:x-amz-acl': 'bucket-owner-full-control'


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:*

Minor improvements to the auto-installer stack:

- Tighten up security posture of the S3 bucket used for CloudTrail
- Download the extension repository to a hidden `.auto-installer` folder instead of the previous `sagemaker-studio-auto-shutdown-extension` - to avoid cluttering up users' home directories and reduce risk of accidental or malicious modification.
- Refresh the repository on run (the previous script would keep using whatever version it had originally downloaded)
- Remove some unused imports from the Lambda

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
