### PR TITLE
Update ext_checker.py

### DIFF
--- a/extension-checker/ext_checker.py
+++ b/extension-checker/ext_checker.py
@@ -38,7 +38,7 @@ def lambda_handler(event, context):
             if not ext_installed:
                 no_ext_list.append({'domain-id': domain_id, 'user-profile': user_profile})
         
-        if len(no_ext_list) > 1:
+        if len(no_ext_list) > 0:
             payload = { 'profiles_with_no_auto_shutdown_ext': no_ext_list }
             sns.publish(TargetArn=topic_arn, Message=json.dumps(payload))
         


### PR DESCRIPTION
*Description of changes:*
At line 41, "> 1" should instead be "> 0" or ">=1", the current value only publishes to SNS if 2 user profiles or more do not have the extension. By changing this value to "> 0" SNS will publish if 1 or more user profile(s) do not have the extension.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
