### PR TITLE
resolveld bug shutting down terminals even though keep_terminals flag…

### DIFF
--- a/sagemaker_studio_autoshutdown/idle_checker.py
+++ b/sagemaker_studio_autoshutdown/idle_checker.py
@@ -282,5 +282,5 @@ class IdleChecker(object):
                     if self.check_notebook(notebook):
                         await self.delete_session(notebook)
                         nb_deleted += 1
-                if num_sessions == nb_deleted:
+                if num_sessions == nb_deleted and (not self.keep_terminals or num_terminals == 0):
                     await self.delete_application(app_name)


### PR DESCRIPTION
… is True

*Issue #, if available: 26

*Description of changes: Added needed logic to prevent unwanted shutdown in case that existing terminals should be kept alive because "keep_terminals"-flag is set to True.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
